### PR TITLE
Add config for ansible-lint-action

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,55 @@
+name: Ansible Lint  # feel free to pick your own name
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # Important: This sets up your GITHUB_WORKSPACE environment variable
+    - uses: actions/checkout@v2
+
+    - name: Lint Ansible Playbook
+      # replace "master" with any valid ref
+      uses: ansible/ansible-lint-action@151b9a2 # https://github.com/ansible/ansible-lint-action/issues/13
+      with:
+        # [required]
+        # Paths to ansible files (i.e., playbooks, tasks, handlers etc..)
+        # or valid Ansible directories according to the Ansible role
+        # directory structure.
+        # If you want to lint multiple ansible files, use the following syntax
+        targets: |
+          playbooks/*.yaml
+          playbooks/*.yml
+          roles/*
+        # [optional]
+        # Arguments to override a package and its version to be set explicitly.
+        # Must follow the example syntax.
+        #override-deps: 
+        #  ansible==2.9
+        #  ansible-lint==4.2.0
+        # [optional]
+        # Arguments to be passed to the ansible-lint
+
+        # Options:
+        #   -q                    quieter, although not silent output
+        #   -p                    parseable output in the format of pep8
+        #   --parseable-severity  parseable output including severity of rule
+        #   -r RULESDIR           specify one or more rules directories using one or
+        #                         more -r arguments. Any -r flags override the default
+        #                         rules in ansiblelint/rules, unless -R is also used.
+        #   -R                    Use default rules in ansiblelint/rules in addition to
+        #                         any extra
+        #                         rules directories specified with -r. There is no need
+        #                         to specify this if no -r flags are used
+        #   -t TAGS               only check rules whose id/tags match these values
+        #   -x SKIP_LIST          only check rules whose id/tags do not match these
+        #                         values
+        #   --nocolor             disable colored output
+        #   --exclude=EXCLUDE_PATHS
+        #                         path to directories or files to skip. This option is
+        #                         repeatable.
+        #   -c C                  Specify configuration file to use. Defaults to ".ansible-lint"
+        args: ""


### PR DESCRIPTION
This PR will add config for the free Github Action provided by official Ansible team called [ansible-lint-action](https://github.com/marketplace/actions/ansible-lint).

Currently we instructed contributors to setup the linter locally, but usage cannot be enforced. Using this action will *enforce* the quality check on PRs before merging.