### PR TITLE
TA1416569 skip DB schema upgrade if DB is upgraded already

### DIFF
--- a/roles/gateway_import_database/README.md
+++ b/roles/gateway_import_database/README.md
@@ -1,7 +1,8 @@
 Import Gateway and OTK Database
 ======================
 
-This role will import Gateway and OTK database dump from ansible controller to destination (remote gateway primary node).
+This role will import Gateway and OTK database dump from ansible controller to destination (remote gateway primary node). 
+It also contains task to upgrade gateway database schema. Once the database schema has been upgraded, it cannot be upgraded again.
 
 Requirements
 ------------

--- a/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
+++ b/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
@@ -1,10 +1,10 @@
 ---
 # This task upgrade the gateway database version.
 
-- name: Check if Gateway Database Schema needs update
+- name: Check if Gateway Database Schema needs update # noqa 305 - no alternative to shell
   no_log: true # don't log decrypted passwords in responses
   shell:
-    cmd: sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }} 'sudo -u layer7 /opt/SecureSpan/Appliance/libexec/ssgconfig_launch -databaseUgrade' 
+    cmd: sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }} '{{ script_db_schema_upgrade }}'
   register: update
   changed_when: false
   delegate_to: localhost
@@ -15,7 +15,7 @@
   expect:
     command: >
       sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }}
-      'sudo -u layer7 /opt/SecureSpan/Appliance/libexec/ssgconfig_launch -databaseUgrade'
+      '{{ script_db_schema_upgrade }}'
     responses:
       "Perform upgrade?": "y"
       "Enter Administrative Database Username": "{{ database_admin_user }}"

--- a/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
+++ b/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
@@ -1,8 +1,17 @@
 ---
 # This task upgrade the gateway database version.
 
+- name: Check if Gateway Database Schema needs update
+  no_log: true # don't log decrypted passwords in responses
+  shell:
+    cmd: sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }} 'sudo -u layer7 /opt/SecureSpan/Appliance/libexec/ssgconfig_launch -databaseUgrade' 
+  register: update
+  changed_when: false
+  delegate_to: localhost
+
 - name: upgrading Gateway Database Schema after import database
   no_log: true # don't log decrypted passwords in responses
+  when:  '"Database upgrade not required" not in update.stdout'
   expect:
     command: >
       sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }}

--- a/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
+++ b/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
@@ -11,7 +11,7 @@
 
 - name: upgrading Gateway Database Schema after import database
   no_log: true # don't log decrypted passwords in responses
-  when:  '"Database upgrade not required" not in update.stdout'
+  when:  '"Database upgrade is required" in update.stdout'
   expect:
     command: >
       sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }}

--- a/roles/gateway_import_database/vars/main.yml
+++ b/roles/gateway_import_database/vars/main.yml
@@ -8,3 +8,5 @@
 command_mysql_create_otkuser: "CREATE USER IF NOT EXISTS '{{ otkdb_user }}'@'{{ inventory_hostname}}' IDENTIFIED BY '{{ otkdb_userpwd }}';"
 # command to grant otk user privileges in destination gateway
 command_mysql_grant_otkuser_privileges: "GRANT SELECT, DELETE, UPDATE, INSERT on {{ otkdb_name }}.* to '{{ otkdb_user }}'@'{{ inventory_hostname}}'; flush privileges;"
+# script to upgrade Gateway database schema
+script_db_schema_upgrade: "sudo -u layer7 /opt/SecureSpan/Appliance/libexec/ssgconfig_launch -databaseUgrade"


### PR DESCRIPTION
re-ran the upgrade Gateway database role and it failed because the database was already upgraded by them previously.

Even though the customer stood up a completely running Gateway before executing the database import role, our playbooks/roles should be allowed to run repeatedly just in case something failed or they need to reallocate a VM instance from another cluster and they need to re-run the upgrade again without human intervention.