### PR TITLE
Feature/use template file for autoprovision roles

### DIFF
--- a/inventories/sample/group_vars/all/vars
+++ b/inventories/sample/group_vars/all/vars
@@ -13,19 +13,19 @@ cluster_host: "{{ hostvars[groups['gateway_primary_db'][0]]['dest'] }}" # Cluste
 cluster_pass: "{{ vault_gateway_cluster_pass }}" # Cluster Passphrase
 
 ### Database configurations
+database_host: "{{ cluster_host }}" # Database Hostname
+database_type: mysql  # The database type, either 'mysql' or 'embedded'
+database_name: ssg  # Database Name
+database_port: 3306  # Database Port
 database_admin_user: root  # Administrative Database Username (not required if joining an existing cluster)
 database_admin_pass: "{{ vault_gateway_database_admin_pass }}"  # Administrative Database Password (not required if joining an existing cluster)
 database_user: gateway  # Database Username
 database_pass: "{{ vault_gateway_database_pass }}"  # Database Password
-database_host: "{{ cluster_host }}" # Database Hostname
-database_port: 3306  # Database Port
-database_name: ssg  # Database Name
 
 ### Node configurations, unused properties should be commented out
 node_enable: true  # Node Enabled State
 configure_node: true  # Configure the node_properties
 configure_db: false  # Creates the database
-database_type: mysql  # The database type, either 'mysql' or 'embedded'
 
 ### OTK database export and import is disabled by default. If the OTK database is located in the Gateway MySQL database,
 # then uncomment the following lines and set the OTK database name and credentials.

--- a/roles/gateway_processing_node/files/gateway_node.properties
+++ b/roles/gateway_processing_node/files/gateway_node.properties
@@ -43,5 +43,5 @@ configure.node=
 ## Database Failover Hostname
 #database.failover.host=
 ## Database Failover Port
-#database.failover.port=3306
+#database.failover.port=
 

--- a/roles/gateway_processing_node/files/gateway_node.properties
+++ b/roles/gateway_processing_node/files/gateway_node.properties
@@ -1,0 +1,47 @@
+#### Headless config create template properties file ####
+
+### Cluster Configuration ###
+## Cluster Hostname (not required if joining an existing cluster)
+cluster.host=
+## Cluster Passphrase
+#cluster.pass=
+
+### Database Connection ###
+## Creates the database
+configure.db=true
+## The database type, either 'mysql' or 'embedded'
+database.type=mysql
+## Database Hostname
+database.host=localhost
+## Database Port
+database.port=3306
+## Database Name
+database.name=ssg
+## Database Username
+database.user=gateway
+## Database Password
+#database.pass=
+## Administrative Database Username (not required if joining an existing cluster)
+database.admin.user=root
+## Administrative Database Password (not required if joining an existing cluster)
+#database.admin.pass=
+
+
+### Node Configuration ###
+## Node Enabled State
+node.enable=true
+## Configure the node.properties
+configure.node=true
+
+### Layer7 API Gateway Policy Manager Administrative Account ###
+## Layer7 API Gateway Policy Manager Username (not required if joining an existing cluster)
+#admin.user=
+## Layer7 API Gateway Policy Manager Password (not required if joining an existing cluster)
+#admin.pass=
+
+### Configure Database Failover Connection ###
+## Database Failover Hostname
+#database.failover.host=
+## Database Failover Port
+#database.failover.port=3306
+

--- a/roles/gateway_processing_node/files/gateway_node.properties
+++ b/roles/gateway_processing_node/files/gateway_node.properties
@@ -8,30 +8,30 @@ cluster.host=
 
 ### Database Connection ###
 ## Creates the database
-configure.db=true
+configure.db=
 ## The database type, either 'mysql' or 'embedded'
-database.type=mysql
+database.type=
 ## Database Hostname
-database.host=localhost
+database.host=
 ## Database Port
-database.port=3306
+database.port=
 ## Database Name
-database.name=ssg
+database.name=
 ## Database Username
-database.user=gateway
+database.user=
 ## Database Password
 #database.pass=
 ## Administrative Database Username (not required if joining an existing cluster)
-database.admin.user=root
+database.admin.user=
 ## Administrative Database Password (not required if joining an existing cluster)
 #database.admin.pass=
 
 
 ### Node Configuration ###
 ## Node Enabled State
-node.enable=true
+node.enable=
 ## Configure the node.properties
-configure.node=true
+configure.node=
 
 ### Layer7 API Gateway Policy Manager Administrative Account ###
 ## Layer7 API Gateway Policy Manager Username (not required if joining an existing cluster)

--- a/roles/gateway_processing_node/tasks/main.yml
+++ b/roles/gateway_processing_node/tasks/main.yml
@@ -50,7 +50,7 @@
         cmd: cat {{ template_file.dest }} | sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_dest_gateway }} '{{ command_autoprovision_node }}'
       register: status
       failed_when: "'Configuration Successful' not in status.stdout"
-    - name: Clean temporary directory
+    - name: Clean node properties temporary directory
       file:
         state: absent
         path: "{{ temp_dir.path }}/"

--- a/roles/gateway_processing_node/tasks/main.yml
+++ b/roles/gateway_processing_node/tasks/main.yml
@@ -10,19 +10,15 @@
 - name: Retrieve node properties template from source gateway, update properties, and use it to auto-provision destination Gateway.
   when: configured.rc != 0 # node is not configured yet
   block:
-    - name: Retrieve the Gateway node properties template file. # noqa 305 - no alternative to shell module
-      no_log: true # don't log decrypted passwords
-      shell:
-        cmd: sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_source_gateway }} {{ command_retrieve_props }}
-      register: template_content
     - name: Create temporary directory to store node properties template files.
       tempfile:
         state: directory
         prefix: "{{ node_props_dir }}"
       register: temp_dir
     - name: Save template text to local file.
+      delegate_to: localhost
       copy:
-        content: "{{ '\r\n'.join(template_content.stdout_lines[2:]) }}" # Ignore first 2 lines of stdout
+        src: gateway_node.properties
         dest: "{{ temp_dir.path }}/{{ inventory_hostname }}.properties"
       register: template_file
     - name: Set values in node properties template file.

--- a/roles/gateway_processing_node/tasks/main.yml
+++ b/roles/gateway_processing_node/tasks/main.yml
@@ -50,3 +50,7 @@
         cmd: cat {{ template_file.dest }} | sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_dest_gateway }} '{{ command_autoprovision_node }}'
       register: status
       failed_when: "'Configuration Successful' not in status.stdout"
+    - name: Clean temporary directory
+      file:
+        state: absent
+        path: "{{ temp_dir.path }}/"

--- a/roles/gateway_processing_node/tasks/main.yml
+++ b/roles/gateway_processing_node/tasks/main.yml
@@ -33,9 +33,16 @@
         - { from: '^cluster.host', to: 'cluster.host={{ cluster_host }}' }
         - { from: '^#cluster.pass', to: 'cluster.pass={{ cluster_pass }}' }
         - { from: '^configure.db', to: 'configure.db={{ configure_db|lower }}' }
+        - { from: '^database.type', to: 'database.type={{ database_type }}' }
         - { from: '^database.host', to: 'database.host={{ database_host }}' }
+        - { from: '^database.name', to: 'database.name={{ database_name }}' }
+        - { from: '^database.port', to: 'database.port={{ database_port }}' }
+        - { from: '^database.user', to: 'database.user={{ database_user }}' }
         - { from: '^#database.pass', to: 'database.pass={{ database_pass }}' }
+        - { from: '^database.admin.user', to: 'database.admin.user={{ database_admin_user }}' }
         - { from: '^#database.admin.pass', to: 'database.admin.pass={{ database_admin_pass }}' }
+        - { from: '^node.enable', to: 'node.enable={{ node_enable }}' }
+        - { from: '^configure.node', to: 'configure.node={{ configure_node }}' }
       register: updated_node_properties
     - name: Auto-provision the new Gateway node.
       no_log: true # don't log decrypted passwords


### PR DESCRIPTION
The template file is an arbitrary file and identical regardless which gateway generates it.
Save a copy of this file in the role instead of ssh to source gateway to generate it.
Added more replace to ensure all custom configured values are populated.
Add clean up of the temp file on controller.
