### PR TITLE
Add tutorial doc for 3-node in-place upgrade.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,7 @@ Remember to set back to true when debugging is done.
     cmd: mysqldump {{ database_name }} --routines -u{{ database_user}}  -p{{ database_pass }} > {{remote_db_temp_dir}}/ssg.sql
 ```
 * For Playbook Debugger please refer to [this guide](https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html)   
+
+## Tutorial
+
+A walkthrough for how to configure and run playbooks for an in-place Gateway upgrade scenario is available in the [TUTORIAL.md](TUTORIAL.md).

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -112,7 +112,7 @@ Follow the setup steps in:
 - [README for gateway_processing_node role](roles/gateway_processing_node/README.md)
 
 The sample [playbooks/gateway-autoprovision-nodes.yml](playbooks/gateway-autoprovision-nodes.yml) will configure all Gateways.
-However, we can only configure the two re-images nodes right now.
+However, we can only configure the two re-imaged nodes right now.
 
 Create a new playbook `playbooks/gateway-autoprovision-database-nodes.yml` containing
 ```yml

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -119,6 +119,7 @@ Create a new playbook `playbooks/gateway-autoprovision-database-nodes.yml` conta
   hosts: gateway_primary_db
   vars:
     ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   roles:
     - gateway_primary_db_node
 
@@ -128,6 +129,7 @@ Create a new playbook `playbooks/gateway-autoprovision-database-nodes.yml` conta
     name: gateway_processing_node
   vars:
     ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
     configure_db: true
 ```
 
@@ -157,6 +159,7 @@ Create a new playbook `playbooks/gateway-autoprovision-processing-nodes.yml` con
   hosts: gateway_processing_node
   vars:
     ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   roles:
     - gateway_processing_node
 ```

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -66,7 +66,7 @@ in `ansible.cfg`, so that the file location does not need supplied as a command-
 
 ## Run Pre-Upgrade Analyzer on Source Gateways
 
-Follow the setup steps in the [README](roles/gateway_preupgrade_analyzer/README.md).
+Follow the setup steps in the [README for gateway_preupgrade_analyzer role](roles/gateway_preupgrade_analyzer/README.md).
 
 Run `ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-preupgrade-analyzer.yml`
 
@@ -77,7 +77,7 @@ Note: If customized, the MySQL 5.7 `my.cnf` file will need to be manually backed
 
 ## Export Gateway Database
 
-Follow the setup steps in the [README](roles/gateway_export_database/README.md)
+Follow the setup steps in the [README for gateway_export_database role](roles/gateway_export_database/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-export.yml`
 
@@ -85,7 +85,7 @@ This takes a database dump of the source Gateway database.
 
 ## Backup Gateway Configurations
 
-Follow the setup steps in the [README](roles/gateway_basic_backup/README.md)
+Follow the setup steps in the [README for gateway_basic_backup role](roles/gateway_basic_backup/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-basic-backup.yml`
 
@@ -99,7 +99,7 @@ Follow TechDocs instructions for [Virtual Machine Re-image](https://techdocs.bro
 
 ## Configure Gateway Database Replication
 
-Follow the setup steps in the [README](roles/gateway_replicate_database/README.md).
+Follow the setup steps in the [README for gateway_replicate_database role](roles/gateway_replicate_database/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-replication.yml`
 
@@ -108,8 +108,8 @@ This playbook will setup replication on the Gateways listed in the inventory und
 ## Configure Database-Node Gateways
 
 Follow the setup steps in:
-- [README](roles/gateway_primary_db_node/README.md)
-- [README](roles/gateway_processing_node/README.md)
+- [README for gateway_primary_db_node role](roles/gateway_primary_db_node/README.md)
+- [README for gateway_processing_node role](roles/gateway_processing_node/README.md)
 
 `ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-nodes.yml`
 
@@ -142,7 +142,7 @@ This playbook will run a headless configuration of the Gateways.
 
 ## Import Gateway Database
 
-Follow the setup steps in the [README](roles/gateway_import_database/README.md).
+Follow the setup steps in the [README for gateway_import_database role](roles/gateway_import_database/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-import.yml`
 
@@ -150,8 +150,7 @@ This will import the database dump from the source Gateway into the new v10 Gate
 
 ## Configure Remaining Processing Gateways 
 
-Follow the setup steps in:
-- [README](roles/gateway_processing_node/README.md)
+Follow the setup steps in the [README for gateway_processing_node role](roles/gateway_processing_node/README.md).
 
 The sample [playbooks/gateway-autoprovision-nodes.yml](playbooks/gateway-autoprovision-nodes.yml) will configure all Gateways.
 However, only need to configure the remaining processing Gateways.
@@ -173,7 +172,7 @@ This playbook will run a headless configuration of the Gateways.
 
 ## Restore Gateway Configurations
 
-Follow the setup steps in the [README](roles/gateway_basic_restore_backup/README.md).
+Follow the setup steps in the [README for gateway_basic_restore_backup role](roles/gateway_basic_restore_backup/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-import.yml`
 
@@ -181,7 +180,7 @@ This will restore the backup Gateway configuration files from the earlier backup
 
 ## Update Destination Gateway Schema
 
-Follow the setup steps in the [README](roles/gateway_import_database/README.md).
+Follow the setup steps in the [README for gateway_import_database role](roles/gateway_import_database/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-upgrade.yml`
 
@@ -189,7 +188,7 @@ This will update the database schema for Gateway v10.
 
 ## Install License using Policy Manager
 
-Follow the setup steps in the [README](roles/gateway_install_license/README.md).
+Follow the setup steps in the [README for gateway_install_license role](roles/gateway_install_license/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-install-license.yml`
 
@@ -202,7 +201,7 @@ to manually remove it using Policy Manager.
 
 If Gateway hostnames were changed after re-imaging, then you would perform this step at this point in the upgrade. 
 
-Follow the setup steps in the [README](roles/gateway_update_otk_hostnames/README.md).
+Follow the setup steps in the [README for gateway_update_otk_hostnames role](roles/gateway_update_otk_hostnames/README.md).
 
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-update-otk-hostnames.yml`
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,213 @@
+# Tutorial
+
+
+This tutorial will walk through the basic workflow of using the Gateway Ansible playbooks and roles.
+
+The exact steps for your upgrade are likely to differ, so the process needs to be adapted to your environment.
+
+## Overview
+
+Review the expedited upgrade documentation on TechDocs: 
+- [Preparing for Expedited Upgrade](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/prep-for-expedited-upgrade.html)
+- [Automating with Ansible](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/automated-expedited-upgrade/automating-with-ansible.html)
+- [Automated Expedited Upgrade Procedure](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/automated-expedited-upgrade.html)
+- [Post Expedited Upgrade Tasks](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/post-upgrade-tasks.html)
+
+## Scenario
+
+For context, the upgrade scenario we will use is an expedited in-place upgrade for a Virtual Appliance Gateway cluster, which will re-use existing VM resources:
+- Starting Point: a Gateway v9.4 cluster with 3 nodes, GW appliance's MySQL v5.7 is configured with failover, and OAuth Toolkit v4.3.1 is installed
+
+- Upgraded Gateways: same as above but with v10.0 Gateways which run a MySQL v8 database.
+
+## Setup Inventory 
+
+Copy the [inventories/sample](/inventories/sample) directory to `inventories/tutorial`.
+
+Update the `hosts` file in this new directory with your Gateway deployment information. Guidelines are [here](inventories/README.md).
+
+Note: for this scenario, the upgraded and source Gateway hostnames are identical!
+
+For example:
+```yaml
+---
+all:
+  hosts:
+  children:
+    gateway:
+      children:
+        gateway_mysql:
+          children:
+            gateway_primary_db:
+              hosts:
+                source-db-gw.placeholder.com:
+                  src: source-db-gw.placeholder.com
+            gateway_failover_db:
+              hosts:
+                source-failover-db-gw.placeholder.com:
+                  src: source-failover-db-gw.placeholder.com
+        gateway_processing_node:
+          hosts:
+            source-processing-gw.placeholder.com:
+                src: source-processing-gw.placeholder.com
+```
+
+## Setup Passwords
+
+Enter Gateway passwords in the inventory's `/group_vars/vault` file. 
+Refer to [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
+
+The commands in this guide assume you are using a vault password file to encrypt the vault file, 
+and that you have [configured the path](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html) 
+in `ansible.cfg` so it does not need supplied as a command-line argument in every step.
+
+## Run Pre-Upgrade Analyzer on Source Gateways
+
+Follow the setup steps in the [README](roles/gateway_preupgrade_analyzer/README.md).
+
+Run `ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-preupgrade-analyzer.yml`
+
+A report is generated, which shows output from a MySQL 8 upgrade checker utility, and lists items that you 
+may need to manually move over to the upgraded Gateways at the end of this process. Review this report before proceeding. 
+
+Note: If customized, the MySQL 5.7 `my.cnf` file will need to be manually backed up and migrated.
+
+## Export Gateway Database
+
+Follow the setup steps in the [README](roles/gateway_export_database/README.md)
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-export.yml`
+
+This takes a database dump of the source Gateway database.
+
+## Backup Gateway Configurations
+
+Follow the setup steps in the [README](roles/gateway_basic_backup/README.md)
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-basic-backup.yml`
+
+This will backup Gateway configuration files on the file system for each source Gateway.
+
+## Re-Image Database Nodes to Gateway v10
+
+At this point, we will need to manually re-image the two source Gateway VMs listed under inventory groups `gateway_primary_db` and `gateway_failover_db`.
+
+Follow TechDocs instructions for [Virtual Machine Re-image](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/virtual-machine-reimage.html).
+
+## Configure Gateway Database Replication
+
+Follow the setup steps in the [README](roles/gateway_replicate_database/README.md).
+
+Run `​ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-replication.yml`
+
+This playbook will setup replication on the Gateways listed in the inventory under groups `gateway_primary_db` and `gateway_failover_db`.
+
+## Configure Database-Node Gateways
+
+Follow the setup steps in:
+- [README](roles/gateway_primary_db_node/README.md)
+- [README](roles/gateway_processing_node/README.md)
+
+`ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-nodes.yml`
+
+The sample [playbooks/gateway-autoprovision-nodes.yml](playbooks/gateway-autoprovision-nodes.yml) will configure all Gateways.
+However, we can only configure the two re-images nodes right now.
+
+Create a new playbook `playbooks/gateway-autoprovision-database-nodes.yml` containing
+```yml
+- name: Autoprovision primary database Gateway node.
+  hosts: gateway_primary_db
+  vars:
+    ansible_connection: local
+  roles:
+    - gateway_primary_db_node
+
+- name: Autoprovision failover database Gateway node.
+  hosts: gateway_failover_db
+  import_role:
+    name: gateway_processing_node
+  vars:
+    ansible_connection: local
+    configure_db: true
+```
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-database-nodes.yml`
+
+This playbook will run a headless configuration of the Gateways.
+
+## Import Gateway Database
+
+Follow the setup steps in the [README](roles/gateway_import_database/README.md).
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-import.yml`
+
+This will import the database dump from the source Gateway into the new v10 Gateway listed under the `gateway_primary_db` inventory group.
+
+## Configure Remaining Processing Gateways 
+
+Follow the setup steps in:
+- [README](roles/gateway_processing_node/README.md)
+
+The sample [playbooks/gateway-autoprovision-nodes.yml](playbooks/gateway-autoprovision-nodes.yml) will configure all Gateways.
+However, only need to configure the remaining processing Gateways.
+
+Create a new playbook `playbooks/gateway-autoprovision-processing-nodes.yml` containing
+```yml
+- name: Autoprovision processing Gateways.
+  hosts: gateway_processing_node
+  vars:
+    ansible_connection: local
+  roles:
+    - gateway_processing_node
+```
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-processing-nodes.yml`
+
+This playbook will run a headless configuration of the Gateways.
+
+## Restore Gateway Configurations
+
+Follow the setup steps in the [README](roles/gateway_basic_restore_backup/README.md).
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-import.yml`
+
+This will restore the backup Gateway configuration files from the earlier backup step.
+
+## Update Destination Gateway Schema
+
+Follow the setup steps in the [README](roles/gateway_import_database/README.md).
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-upgrade.yml`
+
+This will update the database schema for Gateway v10.
+
+## Install license using Policy Manager
+
+Follow the setup steps in the [README](roles/gateway_install_license/README.md).
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-install-license.yml`
+
+This will install your license file onto the Gateway cluster. The existing v9 license is not removed, you will need
+to manually remove it using Policy Manager.
+
+## Update Hostnames used by OAuth Toolkit
+
+** This step does not apply for this scenario! Gateway hostnames are not being changed. **
+
+If Gateway hostnames were changed after re-imaging, then you would perform this step at this point in the upgrade. 
+
+Follow the setup steps in the [README](roles/gateway_update_otk_hostnames/README.md).
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-update-otk-hostnames.yml`
+
+This will update the Gateway hostnames used by OAuth Toolkit.
+
+## Restart Gateways 
+
+Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-restart.yml`
+
+This will restart all of the Gateways in the upgraded cluster. 
+
+## Verify the Upgraded Gateways
+
+Run your verification procedures to ensure the Gateways are running successfully.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -57,7 +57,7 @@ all:
 
 ## Setup Passwords
 
-Enter Gateway passwords in the inventory's `/group_vars/vault` file. 
+Enter Gateway passwords in the inventory's `/group_vars/all/vault` file. 
 Refer to [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
 
 The commands in this guide assume you are using a vault password file to encrypt the vault file, 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -61,8 +61,8 @@ Enter Gateway passwords in the inventory's `/group_vars/vault` file.
 Refer to [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html).
 
 The commands in this guide assume you are using a vault password file to encrypt the vault file, 
-and that you have [configured the path](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html) 
-in `ansible.cfg` so it does not need supplied as a command-line argument in every step.
+and that you have [configured the path to the vault password file](https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html) 
+in `ansible.cfg`, so that the file location does not need supplied as a command-line argument in every step.
 
 ## Run Pre-Upgrade Analyzer on Source Gateways
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -181,7 +181,7 @@ Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-datab
 
 This will update the database schema for Gateway v10.
 
-## Install license using Policy Manager
+## Install License using Policy Manager
 
 Follow the setup steps in the [README](roles/gateway_install_license/README.md).
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -199,7 +199,7 @@ to manually remove it using Policy Manager.
 
 ## Update Hostnames used by OAuth Toolkit
 
-** This step does not apply for this scenario! Gateway hostnames are not being changed. **
+**This step does not apply for this scenario! Gateway hostnames are not being changed.**
 
 If Gateway hostnames were changed after re-imaging, then you would perform this step at this point in the upgrade. 
 
@@ -214,6 +214,10 @@ This will update the Gateway hostnames used by OAuth Toolkit.
 Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-restart.yml`
 
 This will restart all of the Gateways in the upgraded cluster. 
+
+## Post-Upgrade Tasks
+
+Run any post-upgrade tasks that apply, based on the pre-upgrade analyzer report, documentation for the previous steps, and the TechDocs page for [Post Expedited Upgrade Tasks](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/post-upgrade-tasks.html).
 
 ## Verify the Upgraded Gateways
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -73,7 +73,7 @@ Run `ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-preupgra
 A report is generated, which shows output from a MySQL 8 upgrade checker utility, and lists items that you 
 may need to manually move over to the upgraded Gateways at the end of this process. Review this report before proceeding. 
 
-Note: If customized, the MySQL 5.7 `my.cnf` file will need to be manually backed up and migrated.
+Note: If customized, the MySQL 5.7 `my.cnf` file will need to be manually backed up and migrated after re-imaging the database node Gateways.
 
 ## Export Gateway Database
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -13,6 +13,10 @@ Review the expedited upgrade documentation on TechDocs:
 - [Automated Expedited Upgrade Procedure](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/automated-expedited-upgrade.html)
 - [Post Expedited Upgrade Tasks](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-enterprise-software/layer7-api-management/api-gateway/10-0/install-configure-upgrade/upgrade-the-gateway/upgrade-an-appliance-gateway/post-upgrade-tasks.html)
 
+Outline of the upgrade steps to follow:
+
+![Steps for in-place upgrade](https://techdocs.broadcom.com/content/dam/broadcom/techdocs/us/en/assets/docops/gateway/ansibleAutoReimage.png/_jcr_content/renditions/original)
+
 ## Scenario
 
 For context, the upgrade scenario we will use is an expedited in-place upgrade for a Virtual Appliance Gateway cluster, which will re-use existing VM resources:

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -19,7 +19,7 @@ Outline of the upgrade steps to follow:
 ## Scenario
 
 For context, the upgrade scenario we will use is an expedited in-place upgrade for a Virtual Appliance Gateway cluster, which will re-use existing VM resources:
-- Starting Point: a Gateway v9.4 cluster with 3 nodes, GW appliance's MySQL v5.7 is configured with failover, and OAuth Toolkit v4.3.1 is installed
+- Starting Point: a Gateway v9.4 cluster with 3 nodes, Gateway MySQL v5.7 database is configured with failover, and OAuth Toolkit v4.3.1 is installed
 
 - Upgraded Gateways: same as above but with v10.0 Gateways which run a MySQL v8 database.
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,6 +1,5 @@
 # Tutorial
 
-
 This tutorial will walk through the basic workflow of using the Gateway Ansible playbooks and roles.
 
 The exact steps for your upgrade are likely to differ, so the process needs to be adapted to your environment.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -27,7 +27,7 @@ For context, the upgrade scenario we will use is an expedited in-place upgrade f
 
 Copy the [inventories/sample](/inventories/sample) directory to `inventories/tutorial`.
 
-Update the `hosts` file in this new directory with your Gateway deployment information. Guidelines are [here](inventories/README.md).
+Update the `hosts.yml` file in this new directory with your Gateway deployment information. Guidelines are [here](inventories/README.md).
 
 Note: for this scenario, the upgraded and source Gateway hostnames are identical!
 
@@ -68,7 +68,7 @@ in `ansible.cfg`, so that the file location does not need supplied as a command-
 
 Follow the setup steps in the [README for gateway_preupgrade_analyzer role](roles/gateway_preupgrade_analyzer/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-preupgrade-analyzer.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-preupgrade-analyzer.yml`
 
 A report is generated, which shows output from a MySQL 8 upgrade checker utility, and lists items that you 
 may need to manually move over to the upgraded Gateways at the end of this process. Review this report before proceeding. 
@@ -79,7 +79,7 @@ Note: If customized, the MySQL 5.7 `my.cnf` file will need to be manually backed
 
 Follow the setup steps in the [README for gateway_export_database role](roles/gateway_export_database/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-export.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-database-export.yml`
 
 This takes a database dump of the source Gateway database.
 
@@ -87,7 +87,7 @@ This takes a database dump of the source Gateway database.
 
 Follow the setup steps in the [README for gateway_basic_backup role](roles/gateway_basic_backup/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-basic-backup.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-basic-backup.yml`
 
 This will backup Gateway configuration files on the file system for each source Gateway.
 
@@ -101,7 +101,7 @@ Follow TechDocs instructions for [Virtual Machine Re-image](https://techdocs.bro
 
 Follow the setup steps in the [README for gateway_replicate_database role](roles/gateway_replicate_database/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-replication.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-database-replication.yml`
 
 This playbook will setup replication on the Gateways listed in the inventory under groups `gateway_primary_db` and `gateway_failover_db`.
 
@@ -134,7 +134,7 @@ Create a new playbook `playbooks/gateway-autoprovision-database-nodes.yml` conta
     configure_db: true
 ```
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-autoprovision-database-nodes.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-autoprovision-database-nodes.yml`
 
 This playbook will run a headless configuration of the Gateways.
 
@@ -142,7 +142,7 @@ This playbook will run a headless configuration of the Gateways.
 
 Follow the setup steps in the [README for gateway_import_database role](roles/gateway_import_database/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-import.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-database-import.yml`
 
 This will import the database dump from the source Gateway into the new v10 Gateway listed under the `gateway_primary_db` inventory group.
 
@@ -164,7 +164,7 @@ Create a new playbook `playbooks/gateway-autoprovision-processing-nodes.yml` con
     - gateway_processing_node
 ```
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-autoprovision-processing-nodes.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-autoprovision-processing-nodes.yml`
 
 This playbook will run a headless configuration of the Gateways.
 
@@ -172,7 +172,7 @@ This playbook will run a headless configuration of the Gateways.
 
 Follow the setup steps in the [README for gateway_basic_restore_backup role](roles/gateway_basic_restore_backup/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-import.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-database-import.yml`
 
 This will restore the backup Gateway configuration files from the earlier backup step.
 
@@ -180,7 +180,7 @@ This will restore the backup Gateway configuration files from the earlier backup
 
 Follow the setup steps in the [README for gateway_import_database role](roles/gateway_import_database/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-upgrade.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-database-upgrade.yml`
 
 This will update the database schema for Gateway v10.
 
@@ -188,7 +188,7 @@ This will update the database schema for Gateway v10.
 
 Follow the setup steps in the [README for gateway_install_license role](roles/gateway_install_license/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-install-license.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-install-license.yml`
 
 This will install your license file onto the Gateway cluster. The existing v9 license is not removed, you will need
 to manually remove it using Policy Manager.
@@ -201,13 +201,13 @@ If Gateway hostnames were changed after re-imaging, then you would perform this 
 
 Follow the setup steps in the [README for gateway_update_otk_hostnames role](roles/gateway_update_otk_hostnames/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-update-otk-hostnames.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-update-otk-hostnames.yml`
 
 This will update the Gateway hostnames used by OAuth Toolkit.
 
 ## Restart Gateways 
 
-Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-restart.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts.yml playbooks/gateway-restart.yml`
 
 This will restart all of the Gateways in the upgraded cluster. 
 

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -68,7 +68,7 @@ in `ansible.cfg`, so that the file location does not need supplied as a command-
 
 Follow the setup steps in the [README for gateway_preupgrade_analyzer role](roles/gateway_preupgrade_analyzer/README.md).
 
-Run `ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-preupgrade-analyzer.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-preupgrade-analyzer.yml`
 
 A report is generated, which shows output from a MySQL 8 upgrade checker utility, and lists items that you 
 may need to manually move over to the upgraded Gateways at the end of this process. Review this report before proceeding. 
@@ -79,7 +79,7 @@ Note: If customized, the MySQL 5.7 `my.cnf` file will need to be manually backed
 
 Follow the setup steps in the [README for gateway_export_database role](roles/gateway_export_database/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-export.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-export.yml`
 
 This takes a database dump of the source Gateway database.
 
@@ -87,7 +87,7 @@ This takes a database dump of the source Gateway database.
 
 Follow the setup steps in the [README for gateway_basic_backup role](roles/gateway_basic_backup/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-basic-backup.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-basic-backup.yml`
 
 This will backup Gateway configuration files on the file system for each source Gateway.
 
@@ -101,7 +101,7 @@ Follow TechDocs instructions for [Virtual Machine Re-image](https://techdocs.bro
 
 Follow the setup steps in the [README for gateway_replicate_database role](roles/gateway_replicate_database/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-replication.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-replication.yml`
 
 This playbook will setup replication on the Gateways listed in the inventory under groups `gateway_primary_db` and `gateway_failover_db`.
 
@@ -110,8 +110,6 @@ This playbook will setup replication on the Gateways listed in the inventory und
 Follow the setup steps in:
 - [README for gateway_primary_db_node role](roles/gateway_primary_db_node/README.md)
 - [README for gateway_processing_node role](roles/gateway_processing_node/README.md)
-
-`ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-nodes.yml`
 
 The sample [playbooks/gateway-autoprovision-nodes.yml](playbooks/gateway-autoprovision-nodes.yml) will configure all Gateways.
 However, we can only configure the two re-images nodes right now.
@@ -136,7 +134,7 @@ Create a new playbook `playbooks/gateway-autoprovision-database-nodes.yml` conta
     configure_db: true
 ```
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-database-nodes.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-autoprovision-database-nodes.yml`
 
 This playbook will run a headless configuration of the Gateways.
 
@@ -144,7 +142,7 @@ This playbook will run a headless configuration of the Gateways.
 
 Follow the setup steps in the [README for gateway_import_database role](roles/gateway_import_database/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-import.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-import.yml`
 
 This will import the database dump from the source Gateway into the new v10 Gateway listed under the `gateway_primary_db` inventory group.
 
@@ -166,7 +164,7 @@ Create a new playbook `playbooks/gateway-autoprovision-processing-nodes.yml` con
     - gateway_processing_node
 ```
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-autoprovision-processing-nodes.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-autoprovision-processing-nodes.yml`
 
 This playbook will run a headless configuration of the Gateways.
 
@@ -174,7 +172,7 @@ This playbook will run a headless configuration of the Gateways.
 
 Follow the setup steps in the [README for gateway_basic_restore_backup role](roles/gateway_basic_restore_backup/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-import.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-import.yml`
 
 This will restore the backup Gateway configuration files from the earlier backup step.
 
@@ -182,7 +180,7 @@ This will restore the backup Gateway configuration files from the earlier backup
 
 Follow the setup steps in the [README for gateway_import_database role](roles/gateway_import_database/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-database-upgrade.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-database-upgrade.yml`
 
 This will update the database schema for Gateway v10.
 
@@ -190,7 +188,7 @@ This will update the database schema for Gateway v10.
 
 Follow the setup steps in the [README for gateway_install_license role](roles/gateway_install_license/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-install-license.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-install-license.yml`
 
 This will install your license file onto the Gateway cluster. The existing v9 license is not removed, you will need
 to manually remove it using Policy Manager.
@@ -203,13 +201,13 @@ If Gateway hostnames were changed after re-imaging, then you would perform this 
 
 Follow the setup steps in the [README for gateway_update_otk_hostnames role](roles/gateway_update_otk_hostnames/README.md).
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-update-otk-hostnames.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-update-otk-hostnames.yml`
 
 This will update the Gateway hostnames used by OAuth Toolkit.
 
 ## Restart Gateways 
 
-Run `​ansible-playbook -i inventories/tutorial/hosts ./playbooks/gateway-restart.yml`
+Run `ansible-playbook -i inventories/tutorial/hosts playbooks/gateway-restart.yml`
 
 This will restart all of the Gateways in the upgraded cluster. 
 


### PR DESCRIPTION
Doc will walk users through the process of configuring/running the playbooks for an in-place upgrade scenario. Based on internal materials from training session.

It is not an exact step-by-step guide since users need to adapt each step to their Gateway environment.