### PR TITLE
Parameterize no log flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,14 +116,10 @@ For example: -vvv for more, -vvvv to enable connection debugging.
 ansible-playbook -i ./inventories/sample gateway-autoprovision-nodes.yml -vvvv
 ```
 * Role task level:
-To keep sensitive values such as decrypted password out of your logs, tasks that expose them are marked with the no_log: true attribute.
-For debugging purpose, you can change setting to "no_log: false " temporarily to enable Ansible output on your terminal. 
-Remember to set back to true when debugging is done.
+To keep sensitive values such as decrypted password out of your logs, tasks that expose them are marked with the no_log attribute and set to true by default.
+For debugging purpose, you can override "no_log" default at the command line to enable Ansible output on your terminal temporarily. 
 ```
-- name: Dump gateway source database
-  no_log: true # don't log decrypted passwords in responses
-  shell: 
-    cmd: mysqldump {{ database_name }} --routines -u{{ database_user}}  -p{{ database_pass }} > {{remote_db_temp_dir}}/ssg.sql
+ansible-playbook playbooks/gateway-autoprovision-nodes.yml --extra-vars no_log=flase
 ```
 * For Playbook Debugger please refer to [this guide](https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html)   
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ansible-playbook -i ./inventories/sample gateway-autoprovision-nodes.yml -vvvv
 To keep sensitive values such as decrypted password out of your logs, tasks that expose them are marked with the no_log attribute and set to true by default.
 For debugging purpose, you can override "no_log" default at the command line to enable Ansible output on your terminal temporarily. 
 ```
-ansible-playbook playbooks/gateway-autoprovision-nodes.yml --extra-vars no_log=flase
+ansible-playbook playbooks/gateway-autoprovision-nodes.yml --extra-vars no_log=false
 ```
 * For Playbook Debugger please refer to [this guide](https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html)   
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ansible-playbook -i ./inventories/sample gateway-autoprovision-nodes.yml -vvvv
 To keep sensitive values such as decrypted password out of your logs, tasks that expose them are marked with the no_log attribute and set to true by default.
 For debugging purpose, you can override "no_log" default at the command line to enable Ansible output on your terminal temporarily. 
 ```
-ansible-playbook playbooks/gateway-autoprovision-nodes.yml --extra-vars no_log=false
+ansible-playbook playbooks/gateway-autoprovision-nodes.yml --extra-vars no_log_flag=false
 ```
 * For Playbook Debugger please refer to [this guide](https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html)   
 

--- a/inventories/sample/group_vars/all/vars
+++ b/inventories/sample/group_vars/all/vars
@@ -48,6 +48,9 @@ port_gateway_health_check: 8080 # default HTTP port is 8080
 # Port used for SSH on Gateways
 port_gateway_ssh: 22
 
+# Default not to log sensitive information
+no_log: true
+
 ### File Locations
 # License bootstrapping configurations
 gateway_bootstrap_dir: "/opt/SecureSpan/Gateway/node/default/etc/bootstrap"  # Don't modify. Gateway server bootstrap location.

--- a/inventories/sample/group_vars/all/vars
+++ b/inventories/sample/group_vars/all/vars
@@ -49,7 +49,7 @@ port_gateway_health_check: 8080 # default HTTP port is 8080
 port_gateway_ssh: 22
 
 # Default not to log sensitive information
-no_log: true
+no_log_flag: true
 
 ### File Locations
 # License bootstrapping configurations

--- a/roles/gateway_common/tasks/initial-update-root-password.yml
+++ b/roles/gateway_common/tasks/initial-update-root-password.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update expired root user password
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   expect:
     command: sshpass -p '{{ gateway_ssgconfig_password }}' ssh {{ ansible_ssh_extra_args }} {{ ansible_user }}@{{ ansible_host }}
     timeout: "{{ gateway_ssh_timeout }}"

--- a/roles/gateway_common/tasks/initial-update-root-password.yml
+++ b/roles/gateway_common/tasks/initial-update-root-password.yml
@@ -1,6 +1,6 @@
 ---
 - name: Update expired root user password
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   expect:
     command: sshpass -p '{{ gateway_ssgconfig_password }}' ssh {{ ansible_ssh_extra_args }} {{ ansible_user }}@{{ ansible_host }}
     timeout: "{{ gateway_ssh_timeout }}"

--- a/roles/gateway_common/tasks/initial-update-ssgconfig-password.yml
+++ b/roles/gateway_common/tasks/initial-update-ssgconfig-password.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if user password is expired # noqa 305 - no alternative to shell
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: sshpass -p '{{ gateway_default_password }}' ssh {{ ansible_ssh_extra_args }} {{ ansible_user }}@{{ ansible_host }} "chage --list {{ ansible_user }}"
   register: expired
@@ -9,7 +9,7 @@
 
 - name: Update expired ssgconfig user password
   when: expired.rc != 0 and 'Your password has expired' in expired.stderr
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   expect:
     command: sshpass -p '{{ gateway_default_password }}' ssh {{ ansible_ssh_extra_args }} {{ ansible_user }}@{{ ansible_host }}
     timeout: "{{ gateway_ssh_timeout }}"

--- a/roles/gateway_common/tasks/initial-update-ssgconfig-password.yml
+++ b/roles/gateway_common/tasks/initial-update-ssgconfig-password.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if user password is expired # noqa 305 - no alternative to shell
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: sshpass -p '{{ gateway_default_password }}' ssh {{ ansible_ssh_extra_args }} {{ ansible_user }}@{{ ansible_host }} "chage --list {{ ansible_user }}"
   register: expired
@@ -9,7 +9,7 @@
 
 - name: Update expired ssgconfig user password
   when: expired.rc != 0 and 'Your password has expired' in expired.stderr
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   expect:
     command: sshpass -p '{{ gateway_default_password }}' ssh {{ ansible_ssh_extra_args }} {{ ansible_user }}@{{ ansible_host }}
     timeout: "{{ gateway_ssh_timeout }}"

--- a/roles/gateway_export_database/tasks/main.yml
+++ b/roles/gateway_export_database/tasks/main.yml
@@ -12,7 +12,7 @@
     state: directory
 
 - name: Dump gateway source database # noqa 305 must use shell
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysqldump {{ database_name }} --routines -u{{ database_user }}  -p{{ database_pass }} > {{ remote_db_temp_dir }}/ssg.sql
   register: status
@@ -30,7 +30,7 @@
   when: otkdb_name is defined
   block:
     - name: Dump otk source database # noqa 305 must use shell
-      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysqldump {{ otkdb_name }} --routines -u{{ database_admin_user }}  -p{{ database_admin_pass }} > {{ remote_db_temp_dir }}/otk.sql
 

--- a/roles/gateway_export_database/tasks/main.yml
+++ b/roles/gateway_export_database/tasks/main.yml
@@ -12,7 +12,7 @@
     state: directory
 
 - name: Dump gateway source database # noqa 305 must use shell
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysqldump {{ database_name }} --routines -u{{ database_user }}  -p{{ database_pass }} > {{ remote_db_temp_dir }}/ssg.sql
   register: status
@@ -30,7 +30,7 @@
   when: otkdb_name is defined
   block:
     - name: Dump otk source database # noqa 305 must use shell
-      no_log: true # don't log decrypted passwords in responses
+      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysqldump {{ otkdb_name }} --routines -u{{ database_admin_user }}  -p{{ database_admin_pass }} > {{ remote_db_temp_dir }}/otk.sql
 

--- a/roles/gateway_import_database/tasks/main.yml
+++ b/roles/gateway_import_database/tasks/main.yml
@@ -8,7 +8,7 @@
     dest: '{{ remote_db_temp_dir }}'
 
 - name: Delete gateway database # noqa 305 must use shell
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysqladmin -u {{ database_user }} -p{{ database_pass }} drop {{ database_name }} -f
   failed_when: false
@@ -16,21 +16,21 @@
   changed_when: status.rc == 0
 
 - name: create gateway database # noqa 305 must use shell
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysqladmin -u {{ database_user }} -p{{ database_pass }} create {{ database_name }}
   register: status
   changed_when: status.rc == 0
 
 - name: import gateway database from source gateway # noqa 305 must use shell
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysql  -u {{ database_user }} -p{{ database_pass }} {{ database_name }} < {{ remote_db_temp_dir }}/ssg.sql
   register: status
   changed_when: status.rc == 0
 
 - name: clean up cluster_info table # noqa 305 must use shell
-  no_log: true
+  no_log: "{{ no_log }}"
   shell:
     cmd: mysql  -u {{ database_user }} -p{{ database_pass }} -e 'truncate table ssg.cluster_info'
   register: status
@@ -40,30 +40,30 @@
   when: otkdb_name is defined
   block:
     - name: create otk user if not exists # noqa 305 must use shell
-      no_log: true # don't log decrypted passwords in responses
+      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysql -u {{ database_admin_user }} -p{{ database_admin_passpwd }} -e "{{ command_mysql_create_otkuser }}"
 
     - name: grant otk user privileges # noqa 305 must use shell
-      no_log: true # don't log decrypted passwords in responses
+      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysql -u {{ database_admin_user }} -p{{ database_admin_pass }} -e "{{ command_mysql_grant_otkuser_privileges }}"
 
     - name: delete otk database # noqa 305 must use shell
-      no_log: true # don't log decrypted passwords in responses
+      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysqladmin  -u {{ database_admin_user }} -p{{ database_admin_pass }} drop {{ otkdb_name }} -f
       failed_when: false
 
     - name: create otk database # noqa 305 must use shell
-      no_log: true # don't log decrypted passwords in responses
+      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysqladmin -u {{ database_admin_user }} -p{{ database_admin_pass }} create {{ otkdb_name }}
       register: status
       changed_when: status.rc == 0
 
     - name: import otk database
-      no_log: true # don't log decrypted passwords in responses
+      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysql -u {{ database_admin_user }} -p{{ database_admin_pass }} {{ otkdb_name }} < {{ remote_db_temp_dir }}/otk.sql
 

--- a/roles/gateway_import_database/tasks/main.yml
+++ b/roles/gateway_import_database/tasks/main.yml
@@ -8,7 +8,7 @@
     dest: '{{ remote_db_temp_dir }}'
 
 - name: Delete gateway database # noqa 305 must use shell
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysqladmin -u {{ database_user }} -p{{ database_pass }} drop {{ database_name }} -f
   failed_when: false
@@ -16,21 +16,21 @@
   changed_when: status.rc == 0
 
 - name: create gateway database # noqa 305 must use shell
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysqladmin -u {{ database_user }} -p{{ database_pass }} create {{ database_name }}
   register: status
   changed_when: status.rc == 0
 
 - name: import gateway database from source gateway # noqa 305 must use shell
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: mysql  -u {{ database_user }} -p{{ database_pass }} {{ database_name }} < {{ remote_db_temp_dir }}/ssg.sql
   register: status
   changed_when: status.rc == 0
 
 - name: clean up cluster_info table # noqa 305 must use shell
-  no_log: "{{ no_log }}"
+  no_log: "{{ no_log_flag }}"
   shell:
     cmd: mysql  -u {{ database_user }} -p{{ database_pass }} -e 'truncate table ssg.cluster_info'
   register: status
@@ -40,30 +40,30 @@
   when: otkdb_name is defined
   block:
     - name: create otk user if not exists # noqa 305 must use shell
-      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysql -u {{ database_admin_user }} -p{{ database_admin_passpwd }} -e "{{ command_mysql_create_otkuser }}"
 
     - name: grant otk user privileges # noqa 305 must use shell
-      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysql -u {{ database_admin_user }} -p{{ database_admin_pass }} -e "{{ command_mysql_grant_otkuser_privileges }}"
 
     - name: delete otk database # noqa 305 must use shell
-      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysqladmin  -u {{ database_admin_user }} -p{{ database_admin_pass }} drop {{ otkdb_name }} -f
       failed_when: false
 
     - name: create otk database # noqa 305 must use shell
-      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysqladmin -u {{ database_admin_user }} -p{{ database_admin_pass }} create {{ otkdb_name }}
       register: status
       changed_when: status.rc == 0
 
     - name: import otk database
-      no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
       shell:
         cmd: mysql -u {{ database_admin_user }} -p{{ database_admin_pass }} {{ otkdb_name }} < {{ remote_db_temp_dir }}/otk.sql
 

--- a/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
+++ b/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
@@ -2,7 +2,7 @@
 # This task upgrade the gateway database version.
 
 - name: upgrading Gateway Database Schema after import database
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   expect:
     command: >
       sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }}

--- a/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
+++ b/roles/gateway_import_database/tasks/upgrade_gateway_database_schema.yml
@@ -2,7 +2,7 @@
 # This task upgrade the gateway database version.
 
 - name: upgrading Gateway Database Schema after import database
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   expect:
     command: >
       sshpass -p '{{ ansible_password }}' ssh ssgconfig@{{ inventory_hostname }}

--- a/roles/gateway_install_license/tasks/main.yml
+++ b/roles/gateway_install_license/tasks/main.yml
@@ -11,7 +11,7 @@
   with_fileglob: "{{ controller_dir_license_location }}/*.xml"
 
 - name: configure Gateway license
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   expect:
     command: sshpass -p '{{ gateway_ssgconfig_password }}' ssh {{ ansible_ssh_extra_args }} ssgconfig@{{ inventory_hostname }}
     timeout: "{{ gateway_ssh_timeout }}"

--- a/roles/gateway_install_license/tasks/main.yml
+++ b/roles/gateway_install_license/tasks/main.yml
@@ -11,7 +11,7 @@
   with_fileglob: "{{ controller_dir_license_location }}/*.xml"
 
 - name: configure Gateway license
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   expect:
     command: sshpass -p '{{ gateway_ssgconfig_password }}' ssh {{ ansible_ssh_extra_args }} ssgconfig@{{ inventory_hostname }}
     timeout: "{{ gateway_ssh_timeout }}"

--- a/roles/gateway_preupgrade_analyzer/tasks/mysql8_compatibility_checker.yml
+++ b/roles/gateway_preupgrade_analyzer/tasks/mysql8_compatibility_checker.yml
@@ -4,13 +4,13 @@
 - name: Grant gateway all privileges to database
   shell:
    cmd: mysql -u{{ database_admin_user }}  -p{{ database_admin_pass }} -e "GRANT ALL PRIVILEGES ON *.* TO '{{ database_user }}'@'%'; flush privileges;"
-  no_log: "{{ no_log }}"
+  no_log: "{{ no_log_flag }}"
   when: inventory_hostname in groups['gateway_mysql']
 
 - name: Run Mysql8 Compatibility Checker
   shell:
     cmd: mysqlsh {{ database_user }}:{{ database_pass }}@{{ inventory_hostname }}:{{ database_port }} -e "util.checkForServerUpgrade();"
-  no_log: "{{ no_log }}"
+  no_log: "{{ no_log_flag }}"
   ignore_errors: True
   register: report_mysql8_compatibility_check
   delegate_to: localhost

--- a/roles/gateway_preupgrade_analyzer/tasks/mysql8_compatibility_checker.yml
+++ b/roles/gateway_preupgrade_analyzer/tasks/mysql8_compatibility_checker.yml
@@ -4,13 +4,13 @@
 - name: Grant gateway all privileges to database
   shell:
    cmd: mysql -u{{ database_admin_user }}  -p{{ database_admin_pass }} -e "GRANT ALL PRIVILEGES ON *.* TO '{{ database_user }}'@'%'; flush privileges;"
-  no_log: true
+  no_log: "{{ no_log }}"
   when: inventory_hostname in groups['gateway_mysql']
 
 - name: Run Mysql8 Compatibility Checker
   shell:
     cmd: mysqlsh {{ database_user }}:{{ database_pass }}@{{ inventory_hostname }}:{{ database_port }} -e "util.checkForServerUpgrade();"
-  no_log: true
+  no_log: "{{ no_log }}"
   ignore_errors: True
   register: report_mysql8_compatibility_check
   delegate_to: localhost

--- a/roles/gateway_processing_node/tasks/main.yml
+++ b/roles/gateway_processing_node/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if destination Gateway node is already configured. # noqa 305 - no alternative to shell module
-  no_log: true # don't log decrypted passwords
+  no_log: "{{ no_log }}" # don't log decrypted passwords
   shell:
     cmd: sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_dest_gateway }} '{{ command_check_node_configured }}'
   register: configured
@@ -22,7 +22,7 @@
         dest: "{{ temp_dir.path }}/{{ inventory_hostname }}.properties"
       register: template_file
     - name: Set values in node properties template file.
-      no_log: true # don't log decrypted passwords
+      no_log: "{{ no_log }}" # don't log decrypted passwords
       lineinfile:
         path: "{{ template_file.dest }}"
         regexp: '{{ item.from }}'
@@ -45,7 +45,7 @@
         - { from: '^configure.node', to: 'configure.node={{ configure_node }}' }
       register: updated_node_properties
     - name: Auto-provision the new Gateway node.
-      no_log: true # don't log decrypted passwords
+      no_log: "{{ no_log }}" # don't log decrypted passwords
       shell:
         cmd: cat {{ template_file.dest }} | sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_dest_gateway }} '{{ command_autoprovision_node }}'
       register: status

--- a/roles/gateway_processing_node/tasks/main.yml
+++ b/roles/gateway_processing_node/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if destination Gateway node is already configured. # noqa 305 - no alternative to shell module
-  no_log: "{{ no_log }}" # don't log decrypted passwords
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords
   shell:
     cmd: sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_dest_gateway }} '{{ command_check_node_configured }}'
   register: configured
@@ -22,7 +22,7 @@
         dest: "{{ temp_dir.path }}/{{ inventory_hostname }}.properties"
       register: template_file
     - name: Set values in node properties template file.
-      no_log: "{{ no_log }}" # don't log decrypted passwords
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords
       lineinfile:
         path: "{{ template_file.dest }}"
         regexp: '{{ item.from }}'
@@ -45,7 +45,7 @@
         - { from: '^configure.node', to: 'configure.node={{ configure_node }}' }
       register: updated_node_properties
     - name: Auto-provision the new Gateway node.
-      no_log: "{{ no_log }}" # don't log decrypted passwords
+      no_log: "{{ no_log_flag }}" # don't log decrypted passwords
       shell:
         cmd: cat {{ template_file.dest }} | sshpass -p '{{ gateway_ssgconfig_password }}' {{ command_ssh_dest_gateway }} '{{ command_autoprovision_node }}'
       register: status

--- a/roles/gateway_replicate_database/tasks/add_slave_user.yml
+++ b/roles/gateway_replicate_database/tasks/add_slave_user.yml
@@ -1,5 +1,5 @@
 - name: Run add_slave_user.sh on {{ master_node }}
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   expect:
     command: >
       sshpass -p '{{ hostvars[master_node].ansible_ssh_pass }}' ssh {{ ansible_ssh_extra_args }}

--- a/roles/gateway_replicate_database/tasks/add_slave_user.yml
+++ b/roles/gateway_replicate_database/tasks/add_slave_user.yml
@@ -1,5 +1,5 @@
 - name: Run add_slave_user.sh on {{ master_node }}
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   expect:
     command: >
       sshpass -p '{{ hostvars[master_node].ansible_ssh_pass }}' ssh {{ ansible_ssh_extra_args }}

--- a/roles/gateway_replicate_database/tasks/create_slave.yml
+++ b/roles/gateway_replicate_database/tasks/create_slave.yml
@@ -1,5 +1,5 @@
 - name: Run create_slave.sh on {{ master_node }}
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   expect:
     command: >
       sshpass -p '{{ hostvars[master_node].ansible_ssh_pass }}' ssh {{ ansible_ssh_extra_args }}

--- a/roles/gateway_replicate_database/tasks/create_slave.yml
+++ b/roles/gateway_replicate_database/tasks/create_slave.yml
@@ -1,5 +1,5 @@
 - name: Run create_slave.sh on {{ master_node }}
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   expect:
     command: >
       sshpass -p '{{ hostvars[master_node].ansible_ssh_pass }}' ssh {{ ansible_ssh_extra_args }}

--- a/roles/gateway_update_otk_hostnames/tasks/update_callback.yml
+++ b/roles/gateway_update_otk_hostnames/tasks/update_callback.yml
@@ -4,7 +4,7 @@
 
 - name: Update OTK callback urls containing [{{ old_callback_hostname }}] to [{{ new_callback_hostname }}] # noqa 305 must use shell
   when: old_callback_hostname and new_callback_hostname
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }} -p{{ db_pass }} {{ db_name }} -e

--- a/roles/gateway_update_otk_hostnames/tasks/update_callback.yml
+++ b/roles/gateway_update_otk_hostnames/tasks/update_callback.yml
@@ -4,7 +4,7 @@
 
 - name: Update OTK callback urls containing [{{ old_callback_hostname }}] to [{{ new_callback_hostname }}] # noqa 305 must use shell
   when: old_callback_hostname and new_callback_hostname
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }} -p{{ db_pass }} {{ db_name }} -e

--- a/roles/gateway_update_otk_hostnames/tasks/update_cluster_hostname.yml
+++ b/roles/gateway_update_otk_hostnames/tasks/update_cluster_hostname.yml
@@ -2,7 +2,7 @@
 # These tasks will update the Gateway cluster.hostname property with then new hostname.
 
 - name: Read old cluster.hostname cluster property # noqa 305 must use shell
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }}  -p{{ db_pass }} {{ db_name }} -s -N -e
@@ -16,7 +16,7 @@
 
 - name: Update Gateway cluster.hostname cluster property from [{{ old_cluster_hostname }}] to [{{ new_cluster_hostname }}] # noqa 305 must use shell
   when: old_cluster_hostname and new_cluster_hostname
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }}  -p{{ db_pass }} {{ db_name }} -e

--- a/roles/gateway_update_otk_hostnames/tasks/update_cluster_hostname.yml
+++ b/roles/gateway_update_otk_hostnames/tasks/update_cluster_hostname.yml
@@ -2,7 +2,7 @@
 # These tasks will update the Gateway cluster.hostname property with then new hostname.
 
 - name: Read old cluster.hostname cluster property # noqa 305 must use shell
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }}  -p{{ db_pass }} {{ db_name }} -s -N -e
@@ -16,7 +16,7 @@
 
 - name: Update Gateway cluster.hostname cluster property from [{{ old_cluster_hostname }}] to [{{ new_cluster_hostname }}] # noqa 305 must use shell
   when: old_cluster_hostname and new_cluster_hostname
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }}  -p{{ db_pass }} {{ db_name }} -e

--- a/roles/gateway_update_otk_hostnames/tasks/update_jdbc_connection.yml
+++ b/roles/gateway_update_otk_hostnames/tasks/update_jdbc_connection.yml
@@ -4,7 +4,7 @@
 
 - name: Update hostnames in OTK JDBC connections # noqa 305 must use shell
   when: old_otk_jdbc_hostname and new_otk_jdbc_hostname
-  no_log: true # don't log decrypted passwords in responses
+  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }} -p{{ db_pass }} {{ db_name }} -e

--- a/roles/gateway_update_otk_hostnames/tasks/update_jdbc_connection.yml
+++ b/roles/gateway_update_otk_hostnames/tasks/update_jdbc_connection.yml
@@ -4,7 +4,7 @@
 
 - name: Update hostnames in OTK JDBC connections # noqa 305 must use shell
   when: old_otk_jdbc_hostname and new_otk_jdbc_hostname
-  no_log: "{{ no_log }}" # don't log decrypted passwords in responses
+  no_log: "{{ no_log_flag }}" # don't log decrypted passwords in responses
   shell:
     cmd: >
       mysql -u{{ db_user }} -p{{ db_pass }} {{ db_name }} -e


### PR DESCRIPTION
Parameterize no_log attribute so that it can be override at command line as needed for easy testing.
By default it won't log sensitive info.