### PR TITLE
Fix the gateway_controller_cleanup/tasks/main.yml to include the vars…

### DIFF
--- a/inventories/sample/group_vars/gateway_papim.yml
+++ b/inventories/sample/group_vars/gateway_papim.yml
@@ -1,31 +1,34 @@
 ---
-    ### PAPIM properties
-    # Override below variables in host_vars for a specific host.
-    ansible_user: root
-    ansible_password: "{{ vault_gateway_root_password }}"
-    papim_user: apmusr
-    papim_user_dir: "/home/{{ papim_user }}"
-    papim_installation_dir: "/opt/apm105"
-    # PAPIM mysql properties will enable papim to read mysql stats (if gateway node contains mysql).
-    # PAPIM keep these values in /home/<papim_user>/.my.cnf
-    papim_read_mysql_stats: false
-    gateway_mysql_host: localhost
-    gateway_mysql_db_name: ssg
-    gateway_mysql_user: gateway
-    gateway_mysql_port: 3306
-    gateway_mysql_password: placeholder
+### PAPIM properties
+# Override below variables in host_vars for a specific host.
+ansible_user: root
+ansible_password: "{{ vault_gateway_root_password }}"
+papim_user: apmusr
+papim_user_dir: "/home/{{ papim_user }}"
+papim_installation_dir: "/opt/apm105"
 
-    ### Additional PAPIM properties to support gateway_papim_install role
-    apm_server_hostname: localhost:5001 # Enter Hostname:Port for APM Server
-    epagent_tcp_port: 9090
-    epagent_rest_port: 9080
-    #plugins are executed periodicially by EPAgent based on a delay
-    epagent_delay_os_resource: 60
-    epagent_delay_operating_status: 900
+# PAPIM mysql properties will enable papim to read mysql stats (if gateway node contains mysql).
+# PAPIM keep these values in /home/<papim_user>/.my.cnf
+papim_read_mysql_stats: false
+gateway_mysql_host: localhost
+gateway_mysql_db_name: ssg
+gateway_mysql_user: gateway
+gateway_mysql_port: 3306
+gateway_mysql_password: placeholder
 
-    # The location on the controller to store the PAPIM configurations of each node.
-    # The folder will be automatically be created on the controller if it does not exist.
-        controller_dir_papim_backup_location: /var/local/papimbackup/
-    # The location on the controller to store the PAPIM installation files.
-    # The folder will be automatically be created on the controller if it does not exist.
-        controller_dir_papim_source_location: /var/local/papimsource/
+### Additional PAPIM properties to support gateway_papim_install role
+apm_server_hostname: localhost:5001 # Enter Hostname:Port for APM Server
+epagent_tcp_port: 9090
+epagent_rest_port: 9080
+
+#plugins are executed periodicially by EPAgent based on a delay
+epagent_delay_os_resource: 60
+epagent_delay_operating_status: 900
+
+# The location on the controller to store the PAPIM configurations of each node.
+# The folder will be automatically be created on the controller if it does not exist.
+controller_dir_papim_backup_location: /var/local/papimbackup/
+
+# The location on the controller to store the PAPIM installation files.
+# The folder will be automatically be created on the controller if it does not exist.
+controller_dir_papim_source_location: /var/local/papimsource/

--- a/roles/gateway_controller_cleanup/tasks/main.yml
+++ b/roles/gateway_controller_cleanup/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 # tasks file for gateway_controller_cleanup
- 
  - name: Setting facts
-   set_fact:    
+   set_fact:
      papim_var_file_path: "{{ ansible_inventory_sources | first }}/group_vars/gateway_papim.yml"
 
  - name: Include vars

--- a/roles/gateway_controller_cleanup/tasks/main.yml
+++ b/roles/gateway_controller_cleanup/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 # tasks file for gateway_controller_cleanup
+ 
+ - name: Setting facts
+   set_fact:    
+     papim_var_file_path: "{{ ansible_inventory_sources | first }}/group_vars/gateway_papim.yml"
+
+ - name: Include vars
+   include_vars: "{{ papim_var_file_path }}"
 
  - name: Delete backup files on Ansible controller created by gateway_basic_backup role.
    local_action: # noqa 504


### PR DESCRIPTION
When running the gateway-controller-cleanup.yml, it will fail with the error:

TASK [gateway_controller_cleanup : Delete backup files on Ansible controller created by gateway_papim_backup role.] ***
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'controller_dir_papim_backup_location' is undefined\n\nThe error appears to be in '/root/ansible/roles/gateway_controller_cleanup/tasks/main.yml': line 10, column 4, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n - name: Delete backup files on Ansible controller created by gateway_papim_backup role.\n   ^ here\n"}

The issue is that the PAPIM related variables are in  inventories/sample/group_vars/gateway_papim.yml including controller_dir_papim_backup_location. But this variable only gets read if there is a host in the gateway_papim_group group.  However, if the customer does not have PAPIM installed, then were will not be a host in the gateway_papim_group, and the gateway_controller-cleanup will fail.